### PR TITLE
Move CI to Bionic Beaver image and install GraphViz

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,10 @@
+dist: bionic
+
+addons:
+  apt:
+    packages:
+      - graphviz
+
 language: go
 go_import_path: github.com/Helcaraxan/gomod
 

--- a/ci/lint.sh
+++ b/ci/lint.sh
@@ -44,7 +44,7 @@ fi
 if [[ -z "$(command -v mdl)" ]] || ! grep "${MARKDOWNLINT_VERSION}" <<<"$(mdl --version)"; then
 	echo "Installing mdl@${MARKDOWNLINT_VERSION}."
 	gem install mdl -v "${MARKDOWNLINT_VERSION}"
-	GEM_INSTALL_DIR="$(gem environment | grep -E -e "- INSTALLATION DIRECTORY" | sed -E 's/.* ([:print:]+)$/\1/')/bin"
+	GEM_INSTALL_DIR="$(gem environment | grep -E -e "- INSTALLATION DIRECTORY" | sed -E 's/.* ([[:print:]]+)$/\1/')/bin"
 	PATH="${PATH}:${GEM_INSTALL_DIR}"
 else
 	echo "Found installed mdl@${MARKDOWNLINT_VERSION}."


### PR DESCRIPTION
Upgrade required to use a more recent environment and the corresponding newer tool versions.

Also allows to easily install the `graphviz` package to allow for the use of the `dot` package.