### PR TITLE
Replace custom teewriter with io.MultiWriter

### DIFF
--- a/lib/internal/util/exec.go
+++ b/lib/internal/util/exec.go
@@ -19,48 +19,28 @@ func RunCommand(logger *logrus.Logger, path string, cmd string, args ...string) 
 		}
 	}
 
-	stdoutWriter := &bufferedTeeWriter{logger: logger}
-	stderrWriter := &bufferedTeeWriter{logger: logger}
+	stdoutBuffer := &bytes.Buffer{}
+	stderrBuffer := &bytes.Buffer{}
 
 	execCmd := exec.Command(cmd, args...)
 	execCmd.Dir = path
-	execCmd.Stdout = stdoutWriter
-	execCmd.Stderr = stderrWriter
+	execCmd.Stdout = stdoutBuffer
+	execCmd.Stderr = stderrBuffer
 
 	if logger.GetLevel() >= logrus.DebugLevel {
-		stdoutWriter.printer = os.Stdout
+		execCmd.Stdout = io.MultiWriter(execCmd.Stdout, os.Stdout)
 	}
 	if logger.GetLevel() >= logrus.WarnLevel {
-		stderrWriter.printer = os.Stderr
+		execCmd.Stderr = io.MultiWriter(execCmd.Stderr, os.Stderr)
 	}
 
 	logger.Debugf("Running command '%s %s'.", execCmd.Path, strings.Join(execCmd.Args, " "))
 	err = execCmd.Run()
-	logger.Debugf("Content of stdout was: %s", stdoutWriter.buffer.Bytes())
-	logger.Debugf("Content of stderr was: %s", stderrWriter.buffer.Bytes())
+	logger.Debugf("Content of stdout was: %s", stdoutBuffer.Bytes())
+	logger.Debugf("Content of stderr was: %s", stderrBuffer.Bytes())
 	if err != nil {
 		logger.WithError(err).Errorf("'%s %s' exited with an error", execCmd.Path, strings.Join(execCmd.Args, " "))
-		return stdoutWriter.buffer.Bytes(), stderrWriter.buffer.Bytes(), fmt.Errorf("failed to run '%s %s: %s", cmd, strings.Join(args, " "), err)
+		return stdoutBuffer.Bytes(), stderrBuffer.Bytes(), fmt.Errorf("failed to run '%s %s: %s", cmd, strings.Join(args, " "), err)
 	}
-	return stdoutWriter.buffer.Bytes(), stderrWriter.buffer.Bytes(), nil
-}
-
-type bufferedTeeWriter struct {
-	logger  *logrus.Logger
-	buffer  bytes.Buffer
-	printer io.Writer
-}
-
-func (w *bufferedTeeWriter) Write(b []byte) (int, error) {
-	n, err := w.buffer.Write(b)
-	if err != nil {
-		w.logger.WithError(err).Error("Could not write to output buffer.")
-		return n, err
-	}
-	if w.printer != nil {
-		if _, err = w.printer.Write(b); err != nil {
-			w.logger.WithError(err).Warn("Terminal output pipe broke. Printed output may be incomplete.")
-		}
-	}
-	return n, nil
+	return stdoutBuffer.Bytes(), stderrBuffer.Bytes(), nil
 }


### PR DESCRIPTION
# Pull Request

## Checklist

<!-- The higher the quality of your PR and its description, the sooner your changes are likely to
get merged. In order to help yourself as well as the project maintainer please read the contribution
guideline -->

- [x] Changes are lint-free. You can check this by running `./ci/lint.sh` or by opening a draft PR
      to trigger the continuous integration pipeline.
- [x] All tests pass. You can check this by running `./ci/test.sh` or by opening a draft PR to
      trigger the continuous integration pipeline.
- [x] If relevant, tests have been updated or added to ensure your changes will not be reverted or
      broken by future PRs.
- [x] If relevant, the project's documentation has been updated or extended.
- [x] If relevant, information has been added to the [release-notes document](../RELEASE_NOTES.md).
- [x] You have filled in the two sections below and deleted their corresponding placeholders texts.

## Summary

Instead of using a custom `teewriter` type we should use the standard `io.MultiWriter` instead as a drop-in replacement.

## Tests

No change in required test-coverage as it's a drop-in replacement and deletes some internal code.
