### PR TITLE
Feature/71 packages in depgraph

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -16,6 +16,7 @@
 - The new `depgraph.Transform` interface type allows for developers using `gomod` as a library to
   make use of external custom filters. This is supported via the new `DepGraph.Transform` method
   that takes the interface type as argument.
+- The `depgraph.Graph` type now contains information for packages as well as for modules.
 - A new `gomod version` enables the printing of the current version of the `gomod` tool.
 
 **Breaking changes**

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -32,13 +32,21 @@
 - The `Logger` field in the `printer.PrintConfig` struct type has been renamed to `Log`.
 - The following types, fields and functions have been renamed:
   - `modules.Module` is now `modules.ModuleInfo`.
-  - `depgraph.GetDephGraph` is now `depgraph.GetModuleGraph`.
+  - `depgraph.GetDephGraph` is now `depgraph.GetGraph`.
   - `depgraph.Dependency` is now `depgraph.Module`.
   - `depgraph.Dependency.Module` is now `depgraph.Module.Info`.
-  - `depgraph.DepGraph` is now `depgraph.ModuleGraph`.
-  - `depgraph.DepGraph.(Get|Add|Remove)Dependency` are now `depgraph.ModuleGraph.(Get|Add|Remove)Module`.
+  - `depgraph.DepGraph` is now `depgraph.Graph`.
+  - `depgraph.Dependencies` is now `depgraph.Modules`.
+  - `depgraph.DepGraph.(Get|Add|Remove)Dependency` are now `depgraph.Graph.(Get|Add|Remove)Module`.
   - `depgraph.DependencyReference` is now `depgraph.ModuleReference`.
   - `depgraph.(New)DependencyMap` are now `depgraph.(New)ModuleDependencies`.
+- The `depgraph.ModuleDependencies` type has been refactored into a more generic
+  `depgraph.Dependencies` type:
+  - It works on a new `depgraph.Reference` interface of which the existing
+    `depgraph.ModuleReference` struct type is an implementation.
+  - Some uses of the `*depgraph.ModuleReference` have been replaced by `depgraph.Reference`. In all
+    these cases it is safe to either continue to pass in a `*depgraph.ModuleReference` or to convert
+    any return value to a `*depgraph.ModuleReference` type.
 
 ## 0.5.0
 

--- a/lib/analysis/analysis.go
+++ b/lib/analysis/analysis.go
@@ -35,7 +35,7 @@ type DepAnalysis struct {
 
 var testCurrentTimeInjection *time.Time
 
-func Analyse(log *zap.Logger, g *depgraph.ModuleGraph) (*DepAnalysis, error) {
+func Analyse(log *zap.Logger, g *depgraph.Graph) (*DepAnalysis, error) {
 	_, moduleMap, err := modules.GetDependenciesWithUpdates(log, g.Path)
 	if err != nil {
 		return nil, err
@@ -47,8 +47,8 @@ func Analyse(log *zap.Logger, g *depgraph.ModuleGraph) (*DepAnalysis, error) {
 		moduleMap: moduleMap,
 	}
 
-	for _, dependency := range g.Dependencies.List() {
-		result.processDependency(dependency)
+	for _, ref := range g.Modules.List() {
+		result.processDependency(ref.(*depgraph.ModuleReference))
 	}
 
 	meanDepAge, maxDepAge, depAgeDistribution := result.depAges.compute()
@@ -74,7 +74,7 @@ func Analyse(log *zap.Logger, g *depgraph.ModuleGraph) (*DepAnalysis, error) {
 
 type analysis struct {
 	log       *zap.Logger
-	graph     *depgraph.ModuleGraph
+	graph     *depgraph.Graph
 	moduleMap map[string]*modules.ModuleInfo
 
 	directDependencies          int

--- a/lib/analysis/analysis_test.go
+++ b/lib/analysis/analysis_test.go
@@ -104,7 +104,7 @@ func TestAnalysis(t *testing.T) {
 			}
 
 			log := zap.New(zapcore.NewCore(logger.NewGoModEncoder(), os.Stdout, zap.DebugLevel))
-			graph, err := depgraph.GetModuleGraph(log, testDir)
+			graph, err := depgraph.GetGraph(log, testDir)
 			require.NoError(t, err)
 
 			analysis, err := Analyse(log, graph)

--- a/lib/depgraph/filters/arbitrary_dependency.go
+++ b/lib/depgraph/filters/arbitrary_dependency.go
@@ -10,7 +10,7 @@ type ArbitraryDependencies struct {
 	Dependencies []string
 }
 
-func (f *ArbitraryDependencies) Apply(log *zap.Logger, graph *depgraph.ModuleGraph) *depgraph.ModuleGraph {
+func (f *ArbitraryDependencies) Apply(log *zap.Logger, graph *depgraph.Graph) *depgraph.Graph {
 	filteredGraph := graph.DeepCopy()
 	for _, dependency := range f.Dependencies {
 		filteredGraph.RemoveModule(dependency)

--- a/lib/depgraph/filters/non_shared.go
+++ b/lib/depgraph/filters/non_shared.go
@@ -10,7 +10,7 @@ type NonSharedDependencies struct {
 	Excludes []string
 }
 
-func (f *NonSharedDependencies) Apply(log *zap.Logger, graph *depgraph.ModuleGraph) *depgraph.ModuleGraph {
+func (f *NonSharedDependencies) Apply(log *zap.Logger, graph *depgraph.Graph) *depgraph.Graph {
 	log.Debug("Pruning dependencies that are not shared between multiple modules.")
 	if len(f.Excludes) > 0 {
 		log.Debug("Excluding dependency from prune.", zap.Strings("exclude-list", f.Excludes))
@@ -25,8 +25,9 @@ func (f *NonSharedDependencies) Apply(log *zap.Logger, graph *depgraph.ModuleGra
 	for {
 		// Find the next unshared dependency.
 		var target *depgraph.ModuleReference
-		for _, dependency := range prunedGraph.Dependencies.List() {
-			_, ok := excludeMap[dependency.Name()]
+		for _, ref := range prunedGraph.Modules.List() {
+			dependency := ref.(*depgraph.ModuleReference)
+			_, ok := excludeMap[ref.Name()]
 			if !ok && len(dependency.Successors.List()) == 0 && len(dependency.Predecessors.List()) <= 1 {
 				target = dependency
 				break
@@ -41,13 +42,13 @@ func (f *NonSharedDependencies) Apply(log *zap.Logger, graph *depgraph.ModuleGra
 	}
 }
 
-func pruneUnsharedChain(graph *depgraph.ModuleGraph, excludeMap map[string]struct{}, leaf *depgraph.ModuleReference) {
+func pruneUnsharedChain(graph *depgraph.Graph, excludeMap map[string]struct{}, leaf *depgraph.ModuleReference) {
 	for {
 		if len(leaf.Predecessors.List()) == 0 {
 			graph.RemoveModule(leaf.Name())
 			return
 		}
-		newLeaf := leaf.Predecessors.List()[0]
+		newLeaf := leaf.Predecessors.List()[0].(*depgraph.ModuleReference)
 		graph.RemoveModule(leaf.Name())
 		_, ok := excludeMap[newLeaf.Name()]
 		if ok || len(newLeaf.Successors.List()) != 0 || len(newLeaf.Predecessors.List()) > 1 {

--- a/lib/depgraph/graph.go
+++ b/lib/depgraph/graph.go
@@ -198,3 +198,18 @@ func (n *Module) Timestamp() *time.Time {
 	}
 	return n.Info.Time
 }
+
+// Package represents a single Go package in a dependency graph.
+type Package struct {
+	Info   *modules.PackageInfo
+	Parent *Module
+
+	Predecessors *Dependencies
+	Successors   *Dependencies
+}
+
+// Name returns the import path of the package and not the value declared inside the package with
+// the 'package' statement.
+func (p *Package) Name() string {
+	return p.Info.ImportPath
+}

--- a/lib/depgraph/graph.go
+++ b/lib/depgraph/graph.go
@@ -12,8 +12,9 @@ import (
 type Graph struct {
 	Path string
 
-	Main    *Module
-	Modules *Dependencies
+	Main     *Module
+	Modules  Dependencies
+	Packages Dependencies
 
 	log      *zap.Logger
 	replaces map[string]string
@@ -38,6 +39,7 @@ func NewGraph(log *zap.Logger, path string, main *modules.ModuleInfo) *Graph {
 	newGraph := &Graph{
 		Path:     path,
 		Modules:  NewDependencies(),
+		Packages: NewDependencies(),
 		log:      log,
 		replaces: map[string]string{},
 	}
@@ -172,8 +174,8 @@ func (g *Graph) Transform(transformations ...Transform) *Graph {
 // Module represents a module in a Go module's dependency graph.
 type Module struct {
 	Info         *modules.ModuleInfo
-	Predecessors *Dependencies
-	Successors   *Dependencies
+	Predecessors Dependencies
+	Successors   Dependencies
 }
 
 // Name of the module represented by this Dependency in the Graph instance.
@@ -204,8 +206,8 @@ type Package struct {
 	Info   *modules.PackageInfo
 	Parent *Module
 
-	Predecessors *Dependencies
-	Successors   *Dependencies
+	Predecessors Dependencies
+	Successors   Dependencies
 }
 
 // Name returns the import path of the package and not the value declared inside the package with

--- a/lib/depgraph/import_deps.go
+++ b/lib/depgraph/import_deps.go
@@ -110,21 +110,13 @@ func (g *Graph) retrievePackageImports(packages []string) (map[string]packageImp
 	}
 	dec := json.NewDecoder(bytes.NewReader(stdout))
 
-	type packageInfo struct {
-		ImportPath   string
-		Module       *modules.ModuleInfo
-		Imports      []string
-		TestImports  []string
-		XTestImports []string
-	}
-
 	isStandardLib := func(pkg string) bool {
 		return !strings.Contains(strings.Split(pkg, "/")[0], ".")
 	}
 
 	infos := map[string]packageImports{}
 	for {
-		info := packageInfo{}
+		info := modules.PackageInfo{}
 		if err = dec.Decode(&info); err != nil {
 			if err == io.EOF {
 				break

--- a/lib/depgraph/import_deps.go
+++ b/lib/depgraph/import_deps.go
@@ -13,7 +13,7 @@ import (
 	"github.com/Helcaraxan/gomod/lib/modules"
 )
 
-func (g *ModuleGraph) buildImportGraph() error {
+func (g *Graph) buildImportGraph() error {
 	g.log.Debug("Building initial dependency graph based on the import graph.")
 
 	pkgs, err := g.retrieveTransitiveImports([]string{fmt.Sprintf("%s/...", g.Main.Info.Path)})
@@ -61,7 +61,7 @@ type packageImports struct {
 	imports []string
 }
 
-func (g *ModuleGraph) retrieveTransitiveImports(pkgs []string) (map[string]packageImports, error) {
+func (g *Graph) retrieveTransitiveImports(pkgs []string) (map[string]packageImports, error) {
 	const maxQueryLength = 950 // This is chosen conservatively to ensure we don't exceed maximum command lengths for 'go list' invocations.
 
 	pkgInfos, queued := map[string]packageImports{}, map[string]bool{}
@@ -102,7 +102,7 @@ func (g *ModuleGraph) retrieveTransitiveImports(pkgs []string) (map[string]packa
 	return pkgInfos, nil
 }
 
-func (g *ModuleGraph) retrievePackageImports(packages []string) (map[string]packageImports, error) {
+func (g *Graph) retrievePackageImports(packages []string) (map[string]packageImports, error) {
 	stdout, _, err := util.RunCommand(g.log, g.Main.Info.Dir, "go", append([]string{"list", "-json"}, packages...)...)
 	if err != nil {
 		g.log.Error("Failed to list imports for packages.", zap.Strings("packages", packages), zap.Error(err))

--- a/lib/depgraph/map.go
+++ b/lib/depgraph/map.go
@@ -7,26 +7,32 @@ type ModuleReference struct {
 	VersionConstraint string
 }
 
-type ModuleDependencies struct {
-	dependencyList []*ModuleReference
-	dependencyMap  map[string]*ModuleReference
+func (m *ModuleReference) Name() string { return m.Module.Name() }
+
+type Reference interface {
+	Name() string
 }
 
-func NewModuleDependencies() *ModuleDependencies {
-	return &ModuleDependencies{
-		dependencyList: []*ModuleReference{},
-		dependencyMap:  map[string]*ModuleReference{},
+type Dependencies struct {
+	dependencyList []Reference
+	dependencyMap  map[string]Reference
+}
+
+func NewDependencies() *Dependencies {
+	return &Dependencies{
+		dependencyList: []Reference{},
+		dependencyMap:  map[string]Reference{},
 	}
 }
 
-func (m *ModuleDependencies) Len() int {
+func (m *Dependencies) Len() int {
 	return len(m.dependencyMap)
 }
 
-func (m *ModuleDependencies) Copy() *ModuleDependencies {
-	newMap := &ModuleDependencies{
-		dependencyMap:  map[string]*ModuleReference{},
-		dependencyList: make([]*ModuleReference, len(m.dependencyList)),
+func (m *Dependencies) Copy() *Dependencies {
+	newMap := &Dependencies{
+		dependencyMap:  map[string]Reference{},
+		dependencyList: make([]Reference, len(m.dependencyList)),
 	}
 	for _, dependency := range m.dependencyMap {
 		newMap.dependencyMap[dependency.Name()] = dependency
@@ -35,7 +41,7 @@ func (m *ModuleDependencies) Copy() *ModuleDependencies {
 	return newMap
 }
 
-func (m *ModuleDependencies) Add(dependencyReference *ModuleReference) {
+func (m *Dependencies) Add(dependencyReference Reference) {
 	if _, ok := m.dependencyMap[dependencyReference.Name()]; ok {
 		return
 	}
@@ -44,12 +50,12 @@ func (m *ModuleDependencies) Add(dependencyReference *ModuleReference) {
 	m.dependencyList = append(m.dependencyList, dependencyReference)
 }
 
-func (m *ModuleDependencies) Get(name string) (*ModuleReference, bool) {
+func (m *Dependencies) Get(name string) (Reference, bool) {
 	dependency, ok := m.dependencyMap[name]
 	return dependency, ok
 }
 
-func (m *ModuleDependencies) Delete(name string) {
+func (m *Dependencies) Delete(name string) {
 	if _, ok := m.dependencyMap[name]; !ok {
 		return
 	}
@@ -62,9 +68,9 @@ func (m *ModuleDependencies) Delete(name string) {
 	}
 }
 
-func (m *ModuleDependencies) List() []*ModuleReference {
+func (m *Dependencies) List() []Reference {
 	sort.Slice(m.dependencyList, func(i int, j int) bool { return m.dependencyList[i].Name() < m.dependencyList[j].Name() })
-	listCopy := make([]*ModuleReference, len(m.dependencyList))
+	listCopy := make([]Reference, len(m.dependencyList))
 	copy(listCopy, m.dependencyList)
 	return listCopy
 }

--- a/lib/depgraph/map.go
+++ b/lib/depgraph/map.go
@@ -18,8 +18,8 @@ type Dependencies struct {
 	dependencyMap  map[string]Reference
 }
 
-func NewDependencies() *Dependencies {
-	return &Dependencies{
+func NewDependencies() Dependencies {
+	return Dependencies{
 		dependencyList: []Reference{},
 		dependencyMap:  map[string]Reference{},
 	}
@@ -29,8 +29,8 @@ func (m *Dependencies) Len() int {
 	return len(m.dependencyMap)
 }
 
-func (m *Dependencies) Copy() *Dependencies {
-	newMap := &Dependencies{
+func (m *Dependencies) Copy() Dependencies {
+	newMap := Dependencies{
 		dependencyMap:  map[string]Reference{},
 		dependencyList: make([]Reference, len(m.dependencyList)),
 	}

--- a/lib/depgraph/map_test.go
+++ b/lib/depgraph/map_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestMapNew(t *testing.T) {
-	newMap := NewModuleDependencies()
+	newMap := NewDependencies()
 	assert.NotNil(t, newMap.dependencyMap)
 	assert.NotNil(t, newMap.dependencyList)
 }
@@ -19,7 +19,7 @@ func TestMapCopy(t *testing.T) {
 	dependencyA := &Module{Info: &modules.ModuleInfo{Path: "dependency_a"}}
 	dependencyB := &Module{Info: &modules.ModuleInfo{Path: "dependency_b"}}
 
-	originalMap := NewModuleDependencies()
+	originalMap := NewDependencies()
 	originalMap.Add(&ModuleReference{Module: dependencyA})
 	copiedMap := originalMap.Copy()
 	originalMap.Add(&ModuleReference{Module: dependencyB})
@@ -38,7 +38,7 @@ func TestMapCopy(t *testing.T) {
 func TestMapAdd(t *testing.T) {
 	dependencyA := &Module{Info: &modules.ModuleInfo{Path: "dependency_a"}}
 
-	newMap := NewModuleDependencies()
+	newMap := NewDependencies()
 	newMap.Add(&ModuleReference{Module: dependencyA})
 	_, ok := newMap.Get("dependency_a")
 	assert.True(t, ok)
@@ -50,7 +50,7 @@ func TestMapAdd(t *testing.T) {
 func TestMapDelete(t *testing.T) {
 	dependencyA := &Module{Info: &modules.ModuleInfo{Path: "dependency_a"}}
 
-	newMap := NewModuleDependencies()
+	newMap := NewDependencies()
 
 	newMap.Delete("dependency_a")
 
@@ -63,7 +63,7 @@ func TestMapLen(t *testing.T) {
 	dependencyA := &Module{Info: &modules.ModuleInfo{Path: "dependency_a"}}
 	dependencyB := &Module{Info: &modules.ModuleInfo{Path: "dependency_b"}}
 
-	newMap := NewModuleDependencies()
+	newMap := NewDependencies()
 	assert.Equal(t, 0, newMap.Len())
 
 	newMap.Add(&ModuleReference{Module: dependencyA})
@@ -83,7 +83,7 @@ func TestMapList(t *testing.T) {
 	dependencyA := &Module{Info: &modules.ModuleInfo{Path: "dependency_a"}}
 	dependencyB := &Module{Info: &modules.ModuleInfo{Path: "dependency_b"}}
 
-	newMap := NewModuleDependencies()
+	newMap := NewDependencies()
 	newMap.Add(&ModuleReference{Module: dependencyB})
 	newMap.Add(&ModuleReference{Module: dependencyA})
 

--- a/lib/depgraph/parser.go
+++ b/lib/depgraph/parser.go
@@ -10,10 +10,10 @@ import (
 
 var depRE = regexp.MustCompile(`^([^@\s]+)@?([^@\s]+)? ([^@\s]+)@([^@\s]+)$`)
 
-// GetModuleGraph will return the dependency graph for the Go module that can be found at the
-// specified path. The 'logger' parameter can be 'nil' which will result in no output or logging
-// information being provided.
-func GetModuleGraph(log *zap.Logger, path string) (*ModuleGraph, error) {
+// GetGraph will return the dependency graph for the Go module that can be found at the specified
+// path. The 'logger' parameter can be 'nil' which will result in no output or logging information
+// being provided.
+func GetGraph(log *zap.Logger, path string) (*Graph, error) {
 	if log == nil {
 		log = zap.NewNop()
 	}
@@ -37,9 +37,10 @@ func GetModuleGraph(log *zap.Logger, path string) (*ModuleGraph, error) {
 		return nil, err
 	}
 
-	for _, dependency := range graph.Dependencies.List() {
-		if dependency.Predecessors.Len() == 0 && dependency.Successors.Len() == 0 {
-			graph.RemoveModule(dependency.Name())
+	for _, ref := range graph.Modules.List() {
+		dep := ref.(*ModuleReference)
+		if dep.Predecessors.Len() == 0 && dep.Successors.Len() == 0 {
+			graph.RemoveModule(dep.Name())
 		}
 	}
 	return graph, nil

--- a/lib/modules/modules.go
+++ b/lib/modules/modules.go
@@ -13,7 +13,8 @@ import (
 	"github.com/Helcaraxan/gomod/lib/internal/util"
 )
 
-// ModuleInfo represents the data returned by 'go list -m --json' for a Go module.
+// ModuleInfo represents the data returned by 'go list -m --json' for a Go module. It's content is
+// extracted directly from the Go documentation.
 type ModuleInfo struct {
 	Main      bool         // is this the main module?
 	Indirect  bool         // is it an indirect dependency?

--- a/lib/modules/packages.go
+++ b/lib/modules/packages.go
@@ -1,0 +1,68 @@
+package modules
+
+// PackageInfo represents the data returned by 'go list --json' for a Go package. It's content is
+// extracted directly from the Go documentation.
+type PackageInfo struct {
+	Dir           string      // directory containing package sources
+	ImportPath    string      // import path of package in dir
+	ImportComment string      // path in import comment on package statement
+	Name          string      // package name
+	Doc           string      // package documentation string
+	Target        string      // install path
+	Shlib         string      // the shared library that contains this package (only set when -linkshared)
+	Goroot        bool        // is this package in the Go root?
+	Standard      bool        // is this package part of the standard Go library?
+	Stale         bool        // would 'go install' do anything for this package?
+	StaleReason   string      // explanation for Stale==true
+	Root          string      // Go root or Go path dir containing this package
+	ConflictDir   string      // this directory shadows Dir in $GOPATH
+	BinaryOnly    bool        // binary-only package (no longer supported)
+	ForTest       string      // package is only for use in named test
+	Export        string      // file containing export data (when using -export)
+	Module        *ModuleInfo // info about package's containing module, if any (can be nil)
+	Match         []string    // command-line patterns matching this package
+	DepOnly       bool        // package is only a dependency, not explicitly listed
+
+	// Source files
+	GoFiles         []string // .go source files (excluding CgoFiles, TestGoFiles, XTestGoFiles)
+	CgoFiles        []string // .go source files that import "C"
+	CompiledGoFiles []string // .go files presented to compiler (when using -compiled)
+	IgnoredGoFiles  []string // .go source files ignored due to build constraints
+	CFiles          []string // .c source files
+	CXXFiles        []string // .cc, .cxx and .cpp source files
+	MFiles          []string // .m source files
+	HFiles          []string // .h, .hh, .hpp and .hxx source files
+	FFiles          []string // .f, .F, .for and .f90 Fortran source files
+	SFiles          []string // .s source files
+	SwigFiles       []string // .swig files
+	SwigCXXFiles    []string // .swigcxx files
+	SysoFiles       []string // .syso object files to add to archive
+	TestGoFiles     []string // _test.go files in package
+	XTestGoFiles    []string // _test.go files outside package
+
+	// Cgo directives
+	CgoCFLAGS    []string // cgo: flags for C compiler
+	CgoCPPFLAGS  []string // cgo: flags for C preprocessor
+	CgoCXXFLAGS  []string // cgo: flags for C++ compiler
+	CgoFFLAGS    []string // cgo: flags for Fortran compiler
+	CgoLDFLAGS   []string // cgo: flags for linker
+	CgoPkgConfig []string // cgo: pkg-config names
+
+	// Dependency information
+	Imports      []string          // import paths used by this package
+	ImportMap    map[string]string // map from source import to ImportPath (identity entries omitted)
+	Deps         []string          // all (recursively) imported dependencies
+	TestImports  []string          // imports from TestGoFiles
+	XTestImports []string          // imports from XTestGoFiles
+
+	// Error information
+	Incomplete bool            // this package or a dependency has an error
+	Error      *PackageError   // error loading package
+	DepsErrors []*PackageError // errors loading dependencies
+}
+
+type PackageError struct {
+	ImportStack []string // shortest path from package named on command line to this one
+	Pos         string   // position of error (if present, file:line:col)
+	Err         string   // the error itself
+}

--- a/lib/reveal/replacements.go
+++ b/lib/reveal/replacements.go
@@ -173,7 +173,7 @@ var (
 	replaceRE       = regexp.MustCompile(`([^\s]+) => ([^\s]+)(?: (v[^\s]+))?`)
 )
 
-func FindReplacements(log *zap.Logger, graph *depgraph.ModuleGraph) (*Replacements, error) {
+func FindReplacements(log *zap.Logger, graph *depgraph.Graph) (*Replacements, error) {
 	replacements := &Replacements{
 		main:            graph.Main.Name(),
 		topLevel:        map[string]string{},
@@ -188,8 +188,8 @@ func FindReplacements(log *zap.Logger, graph *depgraph.ModuleGraph) (*Replacemen
 		replacements.topLevel[replace.Original] = replace.Override
 	}
 
-	for _, node := range graph.Dependencies.List() {
-		replaces, err = parseGoMod(log, graph.Main.Info, replacements.topLevel, node.Info)
+	for _, ref := range graph.Modules.List() {
+		replaces, err = parseGoMod(log, graph.Main.Info, replacements.topLevel, ref.(*depgraph.ModuleReference).Info)
 		if err != nil {
 			return nil, err
 		}

--- a/lib/reveal/replacements_test.go
+++ b/lib/reveal/replacements_test.go
@@ -95,7 +95,7 @@ var (
 	}
 )
 
-var testGraph *depgraph.ModuleGraph
+var testGraph *depgraph.Graph
 
 func init() {
 	log := zap.NewNop()

--- a/main.go
+++ b/main.go
@@ -206,7 +206,7 @@ func runGraphCmd(args *graphArgs) error {
 		return errors.New("'shared' and 'dependencies' filters cannot be used simultaneously")
 	}
 
-	graph, err := depgraph.GetModuleGraph(args.log, "")
+	graph, err := depgraph.GetGraph(args.log, "")
 	if err != nil {
 		return err
 	}
@@ -254,7 +254,7 @@ func initAnalyseCmd(cArgs *commonArgs) *cobra.Command {
 }
 
 func runAnalyseCmd(args *analyseArgs) error {
-	graph, err := depgraph.GetModuleGraph(args.log, "")
+	graph, err := depgraph.GetGraph(args.log, "")
 	if err != nil {
 		return err
 	}
@@ -291,7 +291,7 @@ func initRevealCmd(cArgs *commonArgs) *cobra.Command {
 }
 
 func runRevealCmd(args *revealArgs) error {
-	graph, err := depgraph.GetModuleGraph(args.log, "")
+	graph, err := depgraph.GetGraph(args.log, "")
 	if err != nil {
 		return err
 	}
@@ -365,7 +365,7 @@ func checkGoModulePresence(log *zap.Logger) error {
 	return errors.New("missing go module")
 }
 
-func printResult(graph *depgraph.ModuleGraph, args *graphArgs) error {
+func printResult(graph *depgraph.Graph, args *graphArgs) error {
 	return printer.Print(graph, &printer.PrintConfig{
 		Log:          args.log,
 		OutputPath:   args.outputPath,


### PR DESCRIPTION
# Pull Request

## Checklist

<!-- The higher the quality of your PR and its description, the sooner your changes are likely to
get merged. In order to help yourself as well as the project maintainer please read the contribution
guideline -->

- [x] Changes are lint-free. You can check this by running `./ci/lint.sh` or by opening a draft PR
      to trigger the continuous integration pipeline.
- [x] All tests pass. You can check this by running `./ci/test.sh` or by opening a draft PR to
      trigger the continuous integration pipeline.
- [x] If relevant, tests have been updated or added to ensure your changes will not be reverted or
      broken by future PRs.
- [x] If relevant, the project's documentation has been updated or extended.
- [x] If relevant, information has been added to the [release-notes document](../RELEASE_NOTES.md).
- [x] You have filled in the two sections below and deleted their corresponding placeholders texts.

## Summary

We're adding package information to the `Graph` struct type. We were already retrieving package-level information but this only used to build the dependency graph but was not stored in persistent fashion. Now this information is stored for further processing an analysis downstream.

## Tests

No new tests as we are not changing the actual logic. Only retaining more data instead of discarding it.