### PR TITLE
Add unit-tests for depgraph query

### DIFF
--- a/internal/depgraph/query_test.go
+++ b/internal/depgraph/query_test.go
@@ -1,0 +1,427 @@
+package depgraph
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/Helcaraxan/gomod/internal/graph"
+	"github.com/Helcaraxan/gomod/internal/modules"
+	"github.com/Helcaraxan/gomod/internal/query"
+	"github.com/Helcaraxan/gomod/internal/testutil"
+)
+
+type queryTestGraph struct {
+	nodes []queryTestNode
+	edges []queryTestEdge
+}
+type queryTestNode struct {
+	name   string
+	isTest bool
+}
+type queryTestEdge struct {
+	s string
+	e string
+}
+
+func instantiateQueryTestGraph(t *testing.T, log *zap.Logger, testGraph queryTestGraph) DepGraph {
+	g := DepGraph{
+		Graph: graph.NewHierarchicalDigraph(),
+		log:   log,
+	}
+
+	nodes := map[string]graph.Node{}
+	for _, node := range testGraph.nodes {
+		module := NewModule(&modules.ModuleInfo{
+			Path: node.name,
+		})
+		module.isNonTestDependency = !node.isTest
+		nodes[node.name] = module
+		require.NoError(t, g.Graph.AddNode(module))
+	}
+	for _, edge := range testGraph.edges {
+		require.NoError(t, g.Graph.AddEdge(nodes[edge.s], nodes[edge.e]))
+	}
+	return g
+}
+
+func TestQueryInvalid(t *testing.T) {
+	t.Parallel()
+
+	testcases := map[string]struct {
+		query             string
+		expectedErrString string
+	}{
+		"Boolean": {
+			query:             "true",
+			expectedErrString: "boolean",
+		},
+		"Integer": {
+			query:             "42",
+			expectedErrString: "integer",
+		},
+		"StringUnknownAnnotation": {
+			query:             "foo:bar",
+			expectedErrString: "undefined",
+		},
+		"StringTooManyAnnotations": {
+			query:             "test:foo:bar",
+			expectedErrString: "more than one",
+		},
+		"DepsFuncTooManyArgs": {
+			query:             "deps(foo, bar, dead, beef)",
+			expectedErrString: "at most",
+		},
+		"DepsFuncWrongTypeSecondArgument": {
+			query:             "deps(foo, bar)",
+			expectedErrString: "expected an integer",
+		},
+		"RDepsFuncTooManyArgs": {
+			query:             "rdeps(foo, bar, dead, beef)",
+			expectedErrString: "at most",
+		},
+		"RDepsFuncWrongTypeSecondArgument": {
+			query:             "rdeps(foo, bar)",
+			expectedErrString: "expected an integer",
+		},
+		"SharedFuncBoolean": {
+			query:             "shared(false)",
+			expectedErrString: "boolean",
+		},
+		"SharedFuncInteger": {
+			query:             "shared(42)",
+			expectedErrString: "integer",
+		},
+		"SharedFuncTooManyArgs": {
+			query:             "shared(foo, bar, com)",
+			expectedErrString: "single argument",
+		},
+		"UnknownFunc": {
+			query:             "foo(bar)",
+			expectedErrString: "unknown function",
+		},
+	}
+
+	for name := range testcases {
+		testcase := testcases[name]
+		t.Run(name, func(t *testing.T) {
+			log := testutil.TestLogger(t)
+			g := DepGraph{
+				Graph: graph.NewHierarchicalDigraph(),
+				log:   log,
+			}
+
+			q, err := query.Parse(log, testcase.query)
+			require.NoError(t, err)
+			set, err := g.computeSet(q, LevelModules)
+			require.True(t, errors.Is(err, ErrInvalidQuery))
+			assert.Contains(t, err.Error(), testcase.expectedErrString)
+			assert.Empty(t, set)
+		})
+	}
+}
+
+func TestQueryNameMatch(t *testing.T) {
+	t.Parallel()
+
+	testcases := map[string]struct {
+		graph       queryTestGraph
+		query       string
+		expectedSet nodeSet
+	}{
+		"Exact": {
+			graph: queryTestGraph{
+				nodes: []queryTestNode{
+					{name: "test.com/module"},
+					{name: "test.com/foo"},
+				},
+			},
+			query: "test.com/module",
+			expectedSet: nodeSet{
+				"test.com/module": true,
+			},
+		},
+		"ExactWithTest": {
+			graph: queryTestGraph{
+				nodes: []queryTestNode{
+					{name: "test.com/module"},
+					{name: "test.com/foo", isTest: true},
+				},
+			},
+			query: "test.com/foo:test",
+			expectedSet: nodeSet{
+				"test.com/foo": true,
+			},
+		},
+		"ExactWithTestNoMatch": {
+			graph: queryTestGraph{
+				nodes: []queryTestNode{
+					{name: "test.com/module"},
+					{name: "test.com/foo"},
+				},
+			},
+			query: "test.com/foo:test",
+			expectedSet: nodeSet{
+				"test.com/foo": true,
+			},
+		},
+		"Prefix": {
+			graph: queryTestGraph{
+				nodes: []queryTestNode{
+					{name: "test.com/module"},
+					{name: "test.com/foo", isTest: true},
+				},
+			},
+			query: "test.com/...",
+			expectedSet: nodeSet{
+				"test.com/module": true,
+			},
+		},
+		"PrefixWithTest": {
+			graph: queryTestGraph{
+				nodes: []queryTestNode{
+					{name: "test.com/module"},
+					{name: "test.com/foo", isTest: true},
+				},
+			},
+			query: "test.com/...:test",
+			expectedSet: nodeSet{
+				"test.com/module": true,
+				"test.com/foo":    true,
+			},
+		},
+	}
+
+	for name := range testcases {
+		testcase := testcases[name]
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			log := testutil.TestLogger(t)
+			g := instantiateQueryTestGraph(t, log, testcase.graph)
+
+			q, err := query.Parse(log, testcase.query)
+			require.NoError(t, err)
+			require.IsType(t, &query.ExprString{}, q)
+
+			set, err := g.computeSet(q, LevelModules)
+			require.NoError(t, err)
+			assert.Equal(t, testcase.expectedSet, set)
+		})
+	}
+}
+
+func TestQueryBinaryOp(t *testing.T) {
+	t.Parallel()
+
+	testcases := map[string]struct {
+		graph       queryTestGraph
+		query       string
+		expectedSet nodeSet
+	}{
+		"Union": {
+			graph: queryTestGraph{
+				nodes: []queryTestNode{
+					{name: "test.com/module"},
+					{name: "test.com/foo"},
+				},
+			},
+			query: "test.com/module + test.com/foo",
+			expectedSet: nodeSet{
+				"test.com/module": true,
+				"test.com/foo":    true,
+			},
+		},
+		"Subtract": {
+			graph: queryTestGraph{
+				nodes: []queryTestNode{
+					{name: "test.com/module"},
+					{name: "test.com/foo"},
+				},
+			},
+			query: "test.com/... - test.com/foo",
+			expectedSet: nodeSet{
+				"test.com/module": true,
+			},
+		},
+		"Intersect": {
+			graph: queryTestGraph{
+				nodes: []queryTestNode{
+					{name: "test.com/module"},
+					{name: "test.com/foo"},
+					{name: "test.com/foo/bar", isTest: true},
+				},
+			},
+			query: "test.com/... inter test.com/foo/...:test",
+			expectedSet: nodeSet{
+				"test.com/foo": true,
+			},
+		},
+		"Delta": {
+			graph: queryTestGraph{
+				nodes: []queryTestNode{
+					{name: "test.com/module"},
+					{name: "test.com/foo"},
+					{name: "test.com/foo/bar", isTest: true},
+				},
+			},
+			query: "test.com/... delta test.com/foo/...:test",
+			expectedSet: nodeSet{
+				"test.com/module":  true,
+				"test.com/foo/bar": true,
+			},
+		},
+	}
+
+	for name := range testcases {
+		testcase := testcases[name]
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			log := testutil.TestLogger(t)
+			g := instantiateQueryTestGraph(t, log, testcase.graph)
+
+			q, err := query.Parse(log, testcase.query)
+			require.NoError(t, err)
+			require.Implements(t, (*query.BinaryExpr)(nil), q)
+
+			set, err := g.computeSet(q, LevelModules)
+			require.NoError(t, err)
+			assert.Equal(t, testcase.expectedSet, set)
+		})
+	}
+}
+
+func TestQueryFuncs(t *testing.T) {
+	t.Parallel()
+
+	testcases := map[string]struct {
+		graph       queryTestGraph
+		query       string
+		expectedSet nodeSet
+	}{
+		"DepsNoLimit": {
+			graph: queryTestGraph{
+				nodes: []queryTestNode{
+					{name: "test.com/module"},
+					{name: "test.com/foo"},
+					{name: "test.com/bar"},
+					{name: "test.com/beef"},
+				},
+				edges: []queryTestEdge{
+					{s: "test.com/module", e: "test.com/foo"},
+					{s: "test.com/foo", e: "test.com/bar"},
+					{s: "test.com/bar", e: "test.com/foo"},
+				},
+			},
+			query: "deps(test.com/module)",
+			expectedSet: nodeSet{
+				"test.com/module": true,
+				"test.com/foo":    true,
+				"test.com/bar":    true,
+			},
+		},
+		"DepsLimit": {
+			graph: queryTestGraph{
+				nodes: []queryTestNode{
+					{name: "test.com/module"},
+					{name: "test.com/foo"},
+					{name: "test.com/bar"},
+				},
+				edges: []queryTestEdge{
+					{s: "test.com/module", e: "test.com/foo"},
+					{s: "test.com/foo", e: "test.com/bar"},
+				},
+			},
+			query: "deps(test.com/module, 1)",
+			expectedSet: nodeSet{
+				"test.com/module": true,
+				"test.com/foo":    true,
+			},
+		},
+		"ReverseDepsNoLimit": {
+			graph: queryTestGraph{
+				nodes: []queryTestNode{
+					{name: "test.com/module"},
+					{name: "test.com/foo"},
+					{name: "test.com/bar"},
+					{name: "test.com/beef"},
+				},
+				edges: []queryTestEdge{
+					{s: "test.com/module", e: "test.com/foo"},
+					{s: "test.com/foo", e: "test.com/bar"},
+				},
+			},
+			query: "rdeps(test.com/bar)",
+			expectedSet: nodeSet{
+				"test.com/module": true,
+				"test.com/foo":    true,
+				"test.com/bar":    true,
+			},
+		},
+		"ReverseDepsLimit": {
+			graph: queryTestGraph{
+				nodes: []queryTestNode{
+					{name: "test.com/module"},
+					{name: "test.com/foo"},
+					{name: "test.com/bar"},
+					{name: "test.com/beef"},
+				},
+				edges: []queryTestEdge{
+					{s: "test.com/module", e: "test.com/foo"},
+					{s: "test.com/foo", e: "test.com/bar"},
+				},
+			},
+			query: "rdeps(test.com/bar, 1)",
+			expectedSet: nodeSet{
+				"test.com/foo": true,
+				"test.com/bar": true,
+			},
+		},
+		"Shared": {
+			graph: queryTestGraph{
+				nodes: []queryTestNode{
+					{name: "test.com/module"},
+					{name: "test.com/foo"},
+					{name: "test.com/bar"},
+					{name: "test.com/dead"},
+					{name: "test.com/beef"},
+				},
+				edges: []queryTestEdge{
+					{s: "test.com/module", e: "test.com/foo"},
+					{s: "test.com/module", e: "test.com/bar"},
+					{s: "test.com/foo", e: "test.com/bar"},
+					{s: "test.com/bar", e: "test.com/dead"},
+					{s: "test.com/dead", e: "test.com/beef"},
+				},
+			},
+			query: "shared(test.com/...)",
+			expectedSet: nodeSet{
+				"test.com/module": true,
+				"test.com/foo":    true,
+				"test.com/bar":    true,
+			},
+		},
+	}
+
+	for name := range testcases {
+		testcase := testcases[name]
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			log := testutil.TestLogger(t)
+			g := instantiateQueryTestGraph(t, log, testcase.graph)
+
+			q, err := query.Parse(log, testcase.query)
+			require.NoError(t, err)
+			require.Implements(t, (*query.FuncExpr)(nil), q)
+
+			set, err := g.computeSet(q, LevelModules)
+			require.NoError(t, err)
+			assert.Equal(t, testcase.expectedSet, set)
+		})
+	}
+}

--- a/internal/query/parser.go
+++ b/internal/query/parser.go
@@ -101,16 +101,7 @@ func (p *parser) parse() (Expr, error) {
 			pos: pos(0, 0),
 		}
 	}
-
-	switch p.exprStack[0].(type) {
-	case *ExprInteger, *ExprBool:
-		return nil, &parserError{
-			err: ErrInvalidArgument,
-			pos: pos(0, p.stream[len(p.stream)-1].Pos().end),
-		}
-	default:
-		return p.exprStack[0], nil
-	}
+	return p.exprStack[0], nil
 }
 
 type rule uint8

--- a/internal/testutil/log.go
+++ b/internal/testutil/log.go
@@ -1,0 +1,31 @@
+package testutil
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+
+	"github.com/Helcaraxan/gomod/internal/logger"
+)
+
+func TestLogger(t *testing.T) *zap.Logger {
+	out := &syncBuffer{Builder: strings.Builder{}}
+	t.Cleanup(func() {
+		if t.Failed() {
+			fmt.Fprintf(os.Stderr, out.String())
+		}
+	})
+
+	fmt.Fprintf(out, "--- Test %s ---", t.Name())
+	return zap.New(zapcore.NewCore(logger.NewGoModEncoder(), out, zapcore.DebugLevel))
+}
+
+type syncBuffer struct {
+	strings.Builder
+}
+
+func (s *syncBuffer) Sync() error { return nil }


### PR DESCRIPTION
# Pull Request

## Checklist

<!-- The higher the quality of your PR and its description, the sooner your changes are likely to
get merged. In order to help yourself as well as the project maintainer please read the contribution
guideline -->

- [x] Changes are lint-free. You can check this by running `./ci/lint.sh` or by opening a draft PR
      to trigger the continuous integration pipeline.
- [x] All tests pass. You can check this by running `./ci/test.sh` or by opening a draft PR to
      trigger the continuous integration pipeline.
- [x] If relevant, tests have been updated or added to ensure your changes will not be reverted or
      broken by future PRs.
- [x] If relevant, the project's documentation has been updated or extended.
- [x] If relevant, information has been added to the [release-notes document](../RELEASE_NOTES.md).
- [x] You have filled in the two sections below and deleted their corresponding placeholders texts.

## Summary

Unit-tests for the graph querying logic! Related to #19. :partying_face: 

## Tests

Tests, tests, tests everywhere!
