### PR TITLE
Increase control over logging granularity

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -18,6 +18,8 @@
 - The `gomod graph` command now support querying the package-level import graph in addition to the
   already available module-level dependency graph. Simply use the new `--package | -p` flag to move
   into package mode.
+- The `--verbose` flag now takes optional string arguments to toggle debug output for specific parts
+  of `gomod`'s logic.
 
 **Breaking changes**
 

--- a/internal/analysis/analysis.go
+++ b/internal/analysis/analysis.go
@@ -9,6 +9,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/Helcaraxan/gomod/internal/depgraph"
+	"github.com/Helcaraxan/gomod/internal/logger"
 	"github.com/Helcaraxan/gomod/internal/modules"
 )
 
@@ -35,7 +36,7 @@ type DepAnalysis struct {
 
 var testCurrentTimeInjection *time.Time
 
-func Analyse(log *zap.Logger, g *depgraph.DepGraph) (*DepAnalysis, error) {
+func Analyse(log *logger.Logger, g *depgraph.DepGraph) (*DepAnalysis, error) {
 	_, moduleMap, err := modules.GetDependenciesWithUpdates(log, g.Path)
 	if err != nil {
 		return nil, err
@@ -73,7 +74,7 @@ func Analyse(log *zap.Logger, g *depgraph.DepGraph) (*DepAnalysis, error) {
 }
 
 type analysis struct {
-	log       *zap.Logger
+	log       *logger.Logger
 	graph     *depgraph.DepGraph
 	moduleMap map[string]*modules.ModuleInfo
 

--- a/internal/analysis/analysis_test.go
+++ b/internal/analysis/analysis_test.go
@@ -10,11 +10,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/zap"
-	"go.uber.org/zap/zapcore"
 
 	"github.com/Helcaraxan/gomod/internal/depgraph"
-	"github.com/Helcaraxan/gomod/internal/logger"
 	"github.com/Helcaraxan/gomod/internal/testutil"
 )
 
@@ -102,11 +99,11 @@ func TestAnalysis(t *testing.T) {
 				defer func() { testCurrentTimeInjection = nil }()
 			}
 
-			log := zap.New(zapcore.NewCore(logger.NewGoModEncoder(), os.Stdout, zap.DebugLevel))
+			log := testutil.TestLogger(t)
 			graph, err := depgraph.GetGraph(log, testDir)
 			require.NoError(t, err)
 
-			analysis, err := Analyse(log, graph)
+			analysis, err := Analyse(log.Log(), graph)
 			require.NoError(t, err)
 			assert.Equal(t, testDefinition.ExpectedDepAnalysis, analysis)
 

--- a/internal/depgraph/graph.go
+++ b/internal/depgraph/graph.go
@@ -1,9 +1,8 @@
 package depgraph
 
 import (
-	"go.uber.org/zap"
-
 	"github.com/Helcaraxan/gomod/internal/graph"
+	"github.com/Helcaraxan/gomod/internal/logger"
 	"github.com/Helcaraxan/gomod/internal/modules"
 )
 
@@ -13,7 +12,6 @@ type DepGraph struct {
 	Main  *Module
 	Graph *graph.HierarchicalDigraph
 
-	log      *zap.Logger
 	replaces map[string]string
 }
 
@@ -24,17 +22,11 @@ const (
 	LevelPackages
 )
 
-// NewGraph returns a new Graph instance which will use the specified logger for writing log output.
-// If a nil value is passed a null-logger will be used instead.
-func NewGraph(log *zap.Logger, path string, main *modules.ModuleInfo) *DepGraph {
-	if log == nil {
-		log = zap.NewNop()
-	}
+func NewGraph(log *logger.Logger, path string, main *modules.ModuleInfo) *DepGraph {
 	g := &DepGraph{
 		Path:     path,
-		Graph:    graph.NewHierarchicalDigraph(),
+		Graph:    graph.NewHierarchicalDigraph(log),
 		replaces: map[string]string{},
-		log:      log,
 	}
 	g.Main = g.AddModule(main)
 	return g

--- a/internal/depgraph/module.go
+++ b/internal/depgraph/module.go
@@ -46,6 +46,10 @@ func (m *Module) Hash() string {
 	return moduleHash(m.Info.Path)
 }
 
+func (m *Module) String() string {
+	return fmt.Sprintf("%s, preds: [%s], succs: [%s]", m.Hash(), m.predecessors, m.successors)
+}
+
 func moduleHash(name string) string {
 	return "module " + name
 }
@@ -114,6 +118,6 @@ func (m *Module) EdgeAttributes(target graph.Node, annotate bool) []string {
 
 var _ testAnnotated = &Module{}
 
-func (m Module) isTestDependency() bool {
+func (m *Module) isTestDependency() bool {
 	return !m.isNonTestDependency
 }

--- a/internal/depgraph/package.go
+++ b/internal/depgraph/package.go
@@ -1,6 +1,8 @@
 package depgraph
 
 import (
+	"fmt"
+
 	"github.com/Helcaraxan/gomod/internal/graph"
 	"github.com/Helcaraxan/gomod/internal/modules"
 )
@@ -27,12 +29,16 @@ func NewPackage(info *modules.PackageInfo, parent *Module) *Package {
 
 // Name returns the import path of the package and not the value declared inside the package with
 // the 'package' statement.
-func (p Package) Name() string {
+func (p *Package) Name() string {
 	return p.Info.ImportPath
 }
 
-func (p Package) Hash() string {
+func (p *Package) Hash() string {
 	return packageHash(p.Info.ImportPath)
+}
+
+func (p *Package) String() string {
+	return fmt.Sprintf("%s, module: %s, preds: [%s], succs: [%s]", p.Hash(), p.parent.Name(), p.predecessors, p.successors)
 }
 
 func packageHash(name string) string { return "package " + name }

--- a/internal/graph/node.go
+++ b/internal/graph/node.go
@@ -3,11 +3,13 @@ package graph
 import (
 	"reflect"
 	"sort"
+	"strings"
 )
 
 type Node interface {
 	Name() string
 	Hash() string
+	String() string
 
 	Predecessors() *NodeRefs
 	Successors() *NodeRefs
@@ -41,6 +43,14 @@ func NewNodeRefs() NodeRefs {
 		nodeMap:  map[string]Node{},
 		weights:  map[string]int{},
 	}
+}
+
+func (n NodeRefs) String() string {
+	var ns []string
+	for _, m := range n.nodeList {
+		ns = append(ns, m.Name())
+	}
+	return strings.Join(ns, ", ")
 }
 
 func (n NodeRefs) Len() int {

--- a/internal/graph/node_test.go
+++ b/internal/graph/node_test.go
@@ -1,6 +1,7 @@
 package graph
 
 import (
+	"fmt"
 	"sort"
 	"testing"
 
@@ -15,8 +16,11 @@ type testNode struct {
 	children NodeRefs
 }
 
-func (n *testNode) Name() string            { return n.name }
-func (n *testNode) Hash() string            { return n.name }
+func (n *testNode) Name() string { return n.name }
+func (n *testNode) Hash() string { return n.name }
+func (n *testNode) String() string {
+	return fmt.Sprintf("%s, preds: [%s], succs: [%s]", n.name, n.preds, n.succs)
+}
 func (n *testNode) Predecessors() *NodeRefs { return &n.preds }
 func (n *testNode) Successors() *NodeRefs   { return &n.succs }
 func (n *testNode) Parent() Node            { return n.parent }

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -1,0 +1,116 @@
+package logger
+
+import (
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+type Domain uint8
+
+const (
+	UnknownDomain Domain = iota
+	AllDomain
+	InitDomain
+	GraphDomain
+	ModuleInfoDomain
+	PackageInfoDomain
+	ModuleDependencyDomain
+	ParserDomain
+	QueryDomain
+	PrinterDomain
+)
+
+func domainFromString(domain string) Domain {
+	return map[string]Domain{
+		"all":     AllDomain,
+		"init":    InitDomain,
+		"graph":   GraphDomain,
+		"modinfo": ModuleInfoDomain,
+		"pkginfo": PackageInfoDomain,
+		"moddeps": ModuleDependencyDomain,
+		"parser":  ParserDomain,
+		"query":   QueryDomain,
+		"printer": PrinterDomain,
+	}[domain]
+}
+
+func stringFromDomain(domain Domain) string {
+	return map[Domain]string{
+		AllDomain:              "all",
+		InitDomain:             "init",
+		GraphDomain:            "graph",
+		ModuleInfoDomain:       "modinfo",
+		PackageInfoDomain:      "pkginfo",
+		ModuleDependencyDomain: "moddeps",
+		ParserDomain:           "parser",
+		QueryDomain:            "query",
+		PrinterDomain:          "printer",
+	}[domain]
+}
+
+type Builder struct {
+	log          *zap.Logger
+	enc          *goModEncoder
+	defaultLevel zapcore.Level
+	domainLevels map[Domain]zapcore.Level
+	cache        map[Domain]*Logger
+}
+
+func NewBuilder(out zapcore.WriteSyncer) *Builder {
+	enc := newEncoder()
+	return &Builder{
+		log:          zap.New(zapcore.NewCore(enc, out, zapcore.DebugLevel)),
+		enc:          enc,
+		domainLevels: map[Domain]zapcore.Level{},
+		cache:        map[Domain]*Logger{},
+	}
+}
+
+func (b *Builder) SetDomainLevel(domain string, level zapcore.Level) {
+	d := domainFromString(domain)
+	switch d {
+	case UnknownDomain:
+		b.log.Warn("Unrecognised logger domain.")
+	case AllDomain:
+		b.defaultLevel = level
+	default:
+		b.domainLevels[d] = level
+	}
+}
+
+func (b *Builder) Log() *Logger {
+	return b.logger(AllDomain)
+}
+
+func (b *Builder) Domain(domain Domain) *Logger {
+	return b.logger(domain)
+}
+
+func (b *Builder) logger(domain Domain) *Logger {
+	if _, ok := b.cache[domain]; !ok {
+		targetLevel := b.defaultLevel
+		if lvl, ok := b.domainLevels[domain]; ok {
+			targetLevel = lvl
+		}
+		b.cache[domain] = &Logger{
+			Logger: b.log.Named(stringFromDomain(domain)).WithOptions(zap.IncreaseLevel(targetLevel)),
+			enc:    b.enc,
+		}
+	}
+	return b.cache[domain]
+}
+
+type Logger struct {
+	*zap.Logger
+	enc *goModEncoder
+}
+
+func (l *Logger) AddIndent() {
+	l.enc.indent++
+}
+
+func (l *Logger) RemoveIndent() {
+	if l.enc.indent > 0 {
+		l.enc.indent--
+	}
+}

--- a/internal/modules/modules.go
+++ b/internal/modules/modules.go
@@ -9,6 +9,7 @@ import (
 
 	"go.uber.org/zap"
 
+	"github.com/Helcaraxan/gomod/internal/logger"
 	"github.com/Helcaraxan/gomod/internal/util"
 )
 
@@ -35,7 +36,7 @@ type ModuleError struct {
 }
 
 // Retrieve the Module information for all dependencies of the Go module found at the specified path.
-func GetDependencies(log *zap.Logger, moduleDir string) (*ModuleInfo, map[string]*ModuleInfo, error) {
+func GetDependencies(log *logger.Logger, moduleDir string) (*ModuleInfo, map[string]*ModuleInfo, error) {
 	return retrieveModuleInformation(log, moduleDir, "all")
 }
 
@@ -43,13 +44,13 @@ func GetDependencies(log *zap.Logger, moduleDir string) (*ModuleInfo, map[string
 // path, including any potentially available updates. This requires internet connectivity in order
 // to return the results. Lack of connectivity should result in an error being returned but this is
 // not a hard guarantee.
-func GetDependenciesWithUpdates(log *zap.Logger, moduleDir string) (*ModuleInfo, map[string]*ModuleInfo, error) {
+func GetDependenciesWithUpdates(log *logger.Logger, moduleDir string) (*ModuleInfo, map[string]*ModuleInfo, error) {
 	return retrieveModuleInformation(log, moduleDir, "all", "-versions", "-u")
 }
 
 // Retrieve the Module information for the specified target module which must be a dependency of the
 // Go module found at the specified path.
-func GetModule(log *zap.Logger, moduleDir string, targetModule string) (*ModuleInfo, error) {
+func GetModule(log *logger.Logger, moduleDir string, targetModule string) (*ModuleInfo, error) {
 	module, _, err := retrieveModuleInformation(log, moduleDir, targetModule)
 	return module, err
 }
@@ -58,13 +59,13 @@ func GetModule(log *zap.Logger, moduleDir string, targetModule string) (*ModuleI
 // Go module found at the specified path, including any potentially available updates. This requires
 // internet connectivity in order to return the results. Lack of connectivity should result in an
 // error being returned but this is not a hard guarantee.
-func GetModuleWithUpdate(log *zap.Logger, moduleDir string, targetModule string) (*ModuleInfo, error) {
+func GetModuleWithUpdate(log *logger.Logger, moduleDir string, targetModule string) (*ModuleInfo, error) {
 	module, _, err := retrieveModuleInformation(log, moduleDir, targetModule, "-versions", "-u")
 	return module, err
 }
 
 func retrieveModuleInformation(
-	log *zap.Logger,
+	log *logger.Logger,
 	moduleDir string,
 	targetModule string,
 	extraGoListArgs ...string,

--- a/internal/modules/modules_test.go
+++ b/internal/modules/modules_test.go
@@ -9,10 +9,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/zap"
-	"go.uber.org/zap/zapcore"
 
-	"github.com/Helcaraxan/gomod/internal/logger"
 	"github.com/Helcaraxan/gomod/internal/testutil"
 )
 
@@ -53,9 +50,9 @@ func TestModuleInformationRetrieval(t *testing.T) {
 			testDefinition := &testcase{}
 			testDir := testutil.SetupTestModule(t, filepath.Join(cwd, "testdata", file.Name()), testDefinition)
 
-			log := zap.New(zapcore.NewCore(logger.NewGoModEncoder(), os.Stdout, zap.DebugLevel))
+			log := testutil.TestLogger(t)
 
-			main, modules, testErr := GetDependencies(log, testDir)
+			main, modules, testErr := GetDependencies(log.Log(), testDir)
 			if testDefinition.ExpectedError {
 				assert.Error(t, testErr)
 			} else {
@@ -64,7 +61,7 @@ func TestModuleInformationRetrieval(t *testing.T) {
 				assert.Equal(t, testDefinition.ExpectedModules, modules)
 			}
 
-			main, modules, testErr = GetDependenciesWithUpdates(log, testDir)
+			main, modules, testErr = GetDependenciesWithUpdates(log.Log(), testDir)
 			if testDefinition.ExpectedError {
 				assert.Error(t, testErr)
 			} else {
@@ -74,11 +71,11 @@ func TestModuleInformationRetrieval(t *testing.T) {
 			}
 
 			if !testDefinition.ExpectedError {
-				main, testErr = GetModule(log, testDir, testDefinition.ExpectedMain.Path)
+				main, testErr = GetModule(log.Log(), testDir, testDefinition.ExpectedMain.Path)
 				require.NoError(t, testErr)
 				assert.Equal(t, testDefinition.ExpectedMain, main)
 
-				main, testErr = GetModuleWithUpdate(log, testDir, testDefinition.ExpectedMain.Path)
+				main, testErr = GetModuleWithUpdate(log.Log(), testDir, testDefinition.ExpectedMain.Path)
 				require.NoError(t, testErr)
 				assert.Equal(t, testDefinition.ExpectedMain, main)
 			}

--- a/internal/parsers/style.go
+++ b/internal/parsers/style.go
@@ -6,10 +6,11 @@ import (
 
 	"go.uber.org/zap"
 
+	"github.com/Helcaraxan/gomod/internal/logger"
 	"github.com/Helcaraxan/gomod/internal/printer"
 )
 
-func ParseStyleConfiguration(logger *zap.Logger, config string) (*printer.StyleOptions, error) {
+func ParseStyleConfiguration(log *logger.Logger, config string) (*printer.StyleOptions, error) {
 	styleOptions := &printer.StyleOptions{}
 	for _, setting := range strings.Split(config, ",") {
 		if setting == "" {
@@ -28,11 +29,11 @@ func ParseStyleConfiguration(logger *zap.Logger, config string) (*printer.StyleO
 		var err error
 		switch configKey {
 		case "scale_nodes":
-			err = parseStyleScaleNodes(logger, styleOptions, configValue)
+			err = parseStyleScaleNodes(log, styleOptions, configValue)
 		case "cluster":
-			err = parseStyleCluster(logger, styleOptions, configValue)
+			err = parseStyleCluster(log, styleOptions, configValue)
 		default:
-			logger.Error("Skipping unknown style option.", zap.String("option", configKey))
+			log.Error("Skipping unknown style option.", zap.String("option", configKey))
 			err = errors.New("invalid config")
 		}
 		if err != nil {
@@ -42,20 +43,20 @@ func ParseStyleConfiguration(logger *zap.Logger, config string) (*printer.StyleO
 	return styleOptions, nil
 }
 
-func parseStyleScaleNodes(logger *zap.Logger, styleOptions *printer.StyleOptions, raw string) error {
+func parseStyleScaleNodes(log *logger.Logger, styleOptions *printer.StyleOptions, raw string) error {
 	switch strings.ToLower(raw) {
 	case "", "true", "on", "yes":
 		styleOptions.ScaleNodes = true
 	case "false", "off", "no":
 		styleOptions.ScaleNodes = false
 	default:
-		logger.Error("Could not set 'scale_nodes' style. Accepted values are 'true' and 'false'.", zap.String("value", raw))
+		log.Error("Could not set 'scale_nodes' style. Accepted values are 'true' and 'false'.", zap.String("value", raw))
 		return errors.New("invalid 'scale_nodes' value")
 	}
 	return nil
 }
 
-func parseStyleCluster(logger *zap.Logger, styleOptions *printer.StyleOptions, raw string) error {
+func parseStyleCluster(log *logger.Logger, styleOptions *printer.StyleOptions, raw string) error {
 	switch strings.ToLower(raw) {
 	case "off", "false", "no":
 		styleOptions.Cluster = printer.Off
@@ -64,7 +65,7 @@ func parseStyleCluster(logger *zap.Logger, styleOptions *printer.StyleOptions, r
 	case "full":
 		styleOptions.Cluster = printer.Full
 	default:
-		logger.Error("Could not set 'cluster' style. Accepted values are 'off', 'shared' and 'full'.", zap.String("value", raw))
+		log.Error("Could not set 'cluster' style. Accepted values are 'off', 'shared' and 'full'.", zap.String("value", raw))
 		return errors.New("invalid 'cluster' value")
 	}
 	return nil

--- a/internal/parsers/style_test.go
+++ b/internal/parsers/style_test.go
@@ -1,16 +1,13 @@
 package parsers
 
 import (
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/zap"
-	"go.uber.org/zap/zapcore"
 
-	"github.com/Helcaraxan/gomod/internal/logger"
 	"github.com/Helcaraxan/gomod/internal/printer"
+	"github.com/Helcaraxan/gomod/internal/testutil"
 )
 
 func TestVisualConfig(t *testing.T) {
@@ -118,8 +115,8 @@ func TestVisualConfig(t *testing.T) {
 	for name := range testcases {
 		testcase := testcases[name]
 		t.Run(name, func(t *testing.T) {
-			log := zap.New(zapcore.NewCore(logger.NewGoModEncoder(), os.Stdout, zap.DebugLevel))
-			config, err := ParseStyleConfiguration(log, testcase.optionValue)
+			log := testutil.TestLogger(t)
+			config, err := ParseStyleConfiguration(log.Log(), testcase.optionValue)
 			if testcase.expectedError {
 				assert.Error(t, err)
 			} else {

--- a/internal/printer/printer.go
+++ b/internal/printer/printer.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/Helcaraxan/gomod/internal/depgraph"
 	"github.com/Helcaraxan/gomod/internal/graph"
+	"github.com/Helcaraxan/gomod/internal/logger"
 	"github.com/Helcaraxan/gomod/internal/util"
 )
 
@@ -24,7 +25,7 @@ const (
 // function of a Graph.
 type PrintConfig struct {
 	// Logger that should be used to show progress while printing the Graph.
-	Log *zap.Logger
+	Log *logger.Logger
 
 	// Which level of granularity to print the graph at (modules, packages).
 	Granularity Level
@@ -220,7 +221,7 @@ func printEdgesToDot(config *PrintConfig, node graph.Node, clusters *graphCluste
 	for _, dep := range node.Successors().List() {
 		cluster, ok := clusters.clusterMap[dep.Hash()]
 		if !ok {
-			config.Log.Error("No cluster reference found for node.", zap.String("node", dep.Hash()))
+			config.Log.Error("No cluster reference found for dependency.", zap.String("node", node.Hash()), zap.String("dep", dep.Hash()))
 			continue
 		} else if _, ok = clustersReached[cluster.id]; ok {
 			continue

--- a/internal/query/parser.go
+++ b/internal/query/parser.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 
 	"go.uber.org/zap"
+
+	"github.com/Helcaraxan/gomod/internal/logger"
 )
 
 var (
@@ -22,7 +24,8 @@ var (
 	ErrUnexpectedParenthesis = errors.New("unexpected parenthesis")
 )
 
-func Parse(log *zap.Logger, query string) (Expr, error) {
+func Parse(dl *logger.Builder, query string) (Expr, error) {
+	log := dl.Domain(logger.ParserDomain)
 	var stream []token
 
 	r := newTokenizer(query)
@@ -60,7 +63,7 @@ func (e *parserError) Unwrap() error {
 }
 
 type parser struct {
-	log       *zap.Logger
+	log       *logger.Logger
 	stream    []token
 	streamIdx int
 	exprStack []Expr

--- a/internal/reveal/replacements.go
+++ b/internal/reveal/replacements.go
@@ -12,6 +12,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/Helcaraxan/gomod/internal/depgraph"
+	"github.com/Helcaraxan/gomod/internal/logger"
 	"github.com/Helcaraxan/gomod/internal/modules"
 )
 
@@ -30,7 +31,7 @@ type Replacements struct {
 	originToReplace map[string][]Replacement
 }
 
-func (r *Replacements) Print(log *zap.Logger, writer io.Writer, offenders []string, targets []string) error {
+func (r *Replacements) Print(log *logger.Logger, writer io.Writer, offenders []string, targets []string) error {
 	filtered := r.FilterOnOffendingModule(offenders).FilterOnReplacedModule(targets)
 
 	var (
@@ -173,7 +174,7 @@ var (
 	replaceRE       = regexp.MustCompile(`([^\s]+) => ([^\s]+)(?: (v[^\s]+))?`)
 )
 
-func FindReplacements(log *zap.Logger, g *depgraph.DepGraph) (*Replacements, error) {
+func FindReplacements(log *logger.Logger, g *depgraph.DepGraph) (*Replacements, error) {
 	replacements := &Replacements{
 		main:            g.Main.Name(),
 		topLevel:        map[string]string{},
@@ -211,7 +212,7 @@ func FindReplacements(log *zap.Logger, g *depgraph.DepGraph) (*Replacements, err
 }
 
 func parseGoMod(
-	log *zap.Logger,
+	log *logger.Logger,
 	topLevelModule *modules.ModuleInfo,
 	topLevelReplaces map[string]string,
 	module *modules.ModuleInfo,
@@ -246,7 +247,7 @@ func parseGoMod(
 	return replaces, nil
 }
 
-func findGoModFile(log *zap.Logger, module *modules.ModuleInfo) (*modules.ModuleInfo, string) {
+func findGoModFile(log *logger.Logger, module *modules.ModuleInfo) (*modules.ModuleInfo, string) {
 	if module == nil {
 		return nil, ""
 	} else if module.Replace != nil {
@@ -265,7 +266,7 @@ func findGoModFile(log *zap.Logger, module *modules.ModuleInfo) (*modules.Module
 	return module, ""
 }
 
-func parseGoModForReplacements(log *zap.Logger, module *modules.ModuleInfo, goModContent string) []Replacement {
+func parseGoModForReplacements(log *logger.Logger, module *modules.ModuleInfo, goModContent string) []Replacement {
 	var replacements []Replacement
 	for _, singleReplaceMatch := range singleReplaceRE.FindAllStringSubmatch(goModContent, -1) {
 		replacements = append(replacements, parseReplacements(log, module, singleReplaceMatch[1])...)
@@ -276,7 +277,7 @@ func parseGoModForReplacements(log *zap.Logger, module *modules.ModuleInfo, goMo
 	return replacements
 }
 
-func parseReplacements(log *zap.Logger, module *modules.ModuleInfo, replaceString string) []Replacement {
+func parseReplacements(log *logger.Logger, module *modules.ModuleInfo, replaceString string) []Replacement {
 	var replacements []Replacement
 	for _, replaceMatch := range replaceRE.FindAllStringSubmatch(replaceString, -1) {
 		replace := Replacement{

--- a/internal/testutil/log.go
+++ b/internal/testutil/log.go
@@ -6,13 +6,12 @@ import (
 	"strings"
 	"testing"
 
-	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 
 	"github.com/Helcaraxan/gomod/internal/logger"
 )
 
-func TestLogger(t *testing.T) *zap.Logger {
+func TestLogger(t *testing.T) *logger.Builder {
 	out := &syncBuffer{Builder: strings.Builder{}}
 	t.Cleanup(func() {
 		if t.Failed() {
@@ -21,7 +20,9 @@ func TestLogger(t *testing.T) *zap.Logger {
 	})
 
 	fmt.Fprintf(out, "--- Test %s ---", t.Name())
-	return zap.New(zapcore.NewCore(logger.NewGoModEncoder(), out, zapcore.DebugLevel))
+	dl := logger.NewBuilder(out)
+	dl.SetDomainLevel("all", zapcore.DebugLevel)
+	return dl
 }
 
 type syncBuffer struct {

--- a/internal/util/fileutil.go
+++ b/internal/util/fileutil.go
@@ -6,36 +6,38 @@ import (
 	"path/filepath"
 
 	"go.uber.org/zap"
+
+	"github.com/Helcaraxan/gomod/internal/logger"
 )
 
 // PrepareOutputPath ensures that the directory containing the specified path exist. It also checks
 // that the full path does not refer to an existing file or directory. If such a path already exists
 // an error is returned.
-func PrepareOutputPath(log *zap.Logger, outputPath string) (*os.File, error) {
-	log = log.With(zap.String("output-path", outputPath))
+func PrepareOutputPath(log *logger.Logger, outputPath string) (*os.File, error) {
+	l := log.With(zap.String("output-path", outputPath))
 	log.Debug("Preparing output path.")
 
 	// Perform target file sanity checks.
 	var sanityCheckErr error
 	if _, err := os.Stat(outputPath); err == nil {
-		log.Error("The specified output path already exists.")
+		l.Error("The specified output path already exists.")
 		sanityCheckErr = fmt.Errorf("target file %q already exists", outputPath)
 	} else if !os.IsNotExist(err) {
-		log.Error("Failed to check if output path already exists.", zap.Error(err))
+		l.Error("Failed to check if output path already exists.", zap.Error(err))
 		sanityCheckErr = fmt.Errorf("could not stat about %q", outputPath)
 	}
 	if sanityCheckErr != nil {
 		return nil, sanityCheckErr
 	}
 
-	log.Debug("Ensuring output path folder exists.")
+	l.Debug("Ensuring output path folder exists.")
 	if err := os.MkdirAll(filepath.Dir(outputPath), 0755); err != nil {
-		log.Error("Failed to create output directory.", zap.Error(err))
+		l.Error("Failed to create output directory.", zap.Error(err))
 		return nil, fmt.Errorf("could not create %q", filepath.Dir(outputPath))
 	}
 	out, err := os.OpenFile(outputPath, os.O_CREATE|os.O_WRONLY, 0644)
 	if err != nil {
-		log.Error("Could not create output file.", zap.Error(err))
+		l.Error("Could not create output file.", zap.Error(err))
 		return nil, err
 	}
 	return out, nil

--- a/main_strings.go
+++ b/main_strings.go
@@ -7,6 +7,24 @@ var (
 
 const (
 	gomodShort = "A tool to visualise and analyse a Go project's dependency graph."
+	gomodLong  = `A CLI tool for interacting with your Go project's dependency graph on various
+levels. See the online documentation or the '--help' for specific sub-commands to discover all the
+supported workflows.
+
+NB: The '--verbose' flag available on each command takes an optional list of strings that allow you 
+    to only get verbose output for specific pieces of logic. The available domains are:
+     * init -> Code that runs before any actual dependency processing happens.
+     * graph -> Interactions on the underlying graph representation used by 'gomod'.
+     * modinfo -> Retrieval of information about all modules involved in the dependency graph.
+     * pkginfo -> Retrieval of information about all packages involves in the dependency graph.
+     * moddeps -> Retrieval of information about module-level dependency graph (e.g versions).
+     * parser -> Parsing of user-specified dependency queries.
+     * query -> Execution of a parsed user-query on the dependency graph.
+     * printer -> Printing of the queried dependency graph.
+     * all -> Covers all domains above.
+    Without any arguments the behaviour defaults to enabling verbosity on all domains, the
+    equivalent of passing 'all' as argument.
+`
 
 	graphShort = "Visualise the dependency graph of a Go module."
 	graphLong  = `Generate a visualisation of the dependency network used by the code in your Go

--- a/main_test.go
+++ b/main_test.go
@@ -3,17 +3,14 @@ package main
 import (
 	"flag"
 	"io/ioutil"
-	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/zap"
-	"go.uber.org/zap/zapcore"
 
-	"github.com/Helcaraxan/gomod/internal/logger"
 	"github.com/Helcaraxan/gomod/internal/printer"
+	"github.com/Helcaraxan/gomod/internal/testutil"
 )
 
 var regenerate = flag.Bool("regenerate", false, "Instead of testing the output, use the generated output to refresh the golden images.")
@@ -61,12 +58,12 @@ func TestGraphGeneration(t *testing.T) {
 		},
 	}
 
-	cArgs := &commonArgs{log: zap.New(zapcore.NewCore(logger.NewGoModEncoder(), os.Stdout, zapcore.DebugLevel))}
-
 	for name := range testcases {
 		testcase := testcases[name]
 		t.Run(name, func(t *testing.T) {
 			tempDir := t.TempDir()
+
+			cArgs := &commonArgs{log: testutil.TestLogger(t)}
 
 			// Test the dot generation.
 			dotArgs := *testcase.dotArgs


### PR DESCRIPTION
# Pull Request

## Checklist

<!-- The higher the quality of your PR and its description, the sooner your changes are likely to
get merged. In order to help yourself as well as the project maintainer please read the contribution
guideline -->

- [x] Changes are lint-free. You can check this by running `./ci/lint.sh` or by opening a draft PR to trigger the continuous integration pipeline.
- [x] All tests pass. You can check this by running `./ci/test.sh` or by opening a draft PR to trigger the continuous integration pipeline.
- [x] If relevant, tests have been updated or added to ensure your changes will not be reverted or broken by future PRs.
- [x] If relevant, the project's documentation has been updated or extended.
- [x] If relevant, information has been added to the [release-notes document](../RELEASE_NOTES.md).
- [x] You have filled in the two sections below and deleted their corresponding placeholders texts.

## Summary

The existing `--verbose` flag is _too_ verbose to allow for useful debugging as a normal run can easily produce >100k lines of output on the project itself. This is addressed in this PR by extending the `--verbose` flag to take an optional list of string arguments that define "domains" for which there should be verbose logging. This allows to focus the verbose printing on specific parts of the dependency parsing, graph building, querying and printing that are of interest for a given debug session.

## Tests

N.A