### PR TITLE
Ensure depgraph.Package implements annotated

### DIFF
--- a/internal/depgraph/package.go
+++ b/internal/depgraph/package.go
@@ -58,3 +58,11 @@ func (p *Package) Children() *graph.NodeRefs {
 func (p *Package) Parent() graph.Node {
 	return p.parent
 }
+
+func (p *Package) NodeAttributes(annotate bool) []string {
+	return nil
+}
+
+func (p *Package) EdgeAttributes(target graph.Node, annotate bool) []string {
+	return nil
+}

--- a/internal/printer/printer.go
+++ b/internal/printer/printer.go
@@ -190,7 +190,7 @@ type annotated interface {
 
 var (
 	_ annotated = &depgraph.Module{}
-	//_ annotated = &depgraph.Package{}
+	_ annotated = &depgraph.Package{}
 )
 
 func printNodeToDot(config *PrintConfig, node graph.Node) string {


### PR DESCRIPTION
# Pull Request

## Checklist

<!-- The higher the quality of your PR and its description, the sooner your changes are likely to
get merged. In order to help yourself as well as the project maintainer please read the contribution
guideline -->

- [x] Changes are lint-free. You can check this by running `./ci/lint.sh` or by opening a draft PR to trigger the continuous integration pipeline.
- [x] All tests pass. You can check this by running `./ci/test.sh` or by opening a draft PR to trigger the continuous integration pipeline.
- [x] If relevant, tests have been updated or added to ensure your changes will not be reverted or broken by future PRs.
- [x] If relevant, the project's documentation has been updated or extended.
- [x] If relevant, information has been added to the [release-notes document](../RELEASE_NOTES.md).
- [x] You have filled in the two sections below and deleted their corresponding placeholders texts.

## Summary

When implementing package-level printing the implementation of the 'annotated' interface was not done which results in panics when using the `--annotate` flag in combination with `--packages`.

## Tests

n.a
