### PR TITLE
Fix test package discovery

### DIFF
--- a/docs/release-notes/next.md
+++ b/docs/release-notes/next.md
@@ -4,6 +4,9 @@
 
 ## Bug fixes
 
+- Not all test-only dependent packages were adequately marked as such. This has been addressed and
+  any packages only imported when building tests are now appropriately recognised as such.
+
 ## New features
 
 ## Breaking changes


### PR DESCRIPTION
# Pull Request

## Checklist

<!-- The higher the quality of your PR and its description, the sooner your changes are likely to
get merged. In order to help yourself as well as the project maintainer please read the contribution
guideline -->

- [x] Changes are lint-free. You can check this by running `./ci/lint.sh` or by opening a draft PR to trigger the continuous integration pipeline.
- [x] All tests pass. You can check this by running `./ci/test.sh` or by opening a draft PR to trigger the continuous integration pipeline.
- [x] If relevant, tests have been updated or added to ensure your changes will not be reverted or broken by future PRs.
- [x] If relevant, the project's documentation has been updated or extended.
- [x] If relevant, information has been added to the [release-notes document](../RELEASE_NOTES.md).
- [x] You have filled in the two sections below and deleted their corresponding placeholders texts.

## Summary

We were inappropriately ranging over all dependencies of non-test packages when marking test-only dependencies. However this should only ever cover non-test imports. This PR addresses this issue.

## Tests

None yet due to lack of a high-level test framework. :sob: 